### PR TITLE
Classroom and Invite Codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ COPY package.json package-lock.json ./
 
 # install packages and copy source 
 RUN npm install
-COPY . . 
 
+RUN cd src/client && npm install && cd ../..
+
+COPY . .
 # pass port to interface and start server
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ COPY package.json package-lock.json ./
 # install packages and copy source 
 RUN npm install
 
-RUN cd src/client && npm install && cd ../..
-
 COPY . .
 # pass port to interface and start server
 EXPOSE 3000

--- a/src/server/models/classrooms.js
+++ b/src/server/models/classrooms.js
@@ -1,43 +1,19 @@
 "use strict";
 
 const mongoose = require("mongoose");
-const crypto = require("crypto");
 
-const userSchema = new mongoose.Schema({
-  email: { type: String, required: true, lowercase: true, index: { unique: true } },
-  password: { type: String, required: true, select: false },
-  name: { type: String, required: true },
-  apiToken: { type: String, default: getToken, unique: true, select: false },
-}, {
-  timestamps: true,
-});
-
-// invite codes need to be unique across all of them
-// how to set unique for all of them?
-// consider different length codes and requirements for string length?
 const classroomSchema = new mongoose.Schema({
     id: { type: String, required: true, lowercase: true, index: { unique: true} },
-    course_type: { type: String, required: true, lowercase: true },
-    course_number: { type: String, required: true, lowercase: true },
-    section_number: { type: String, required: false, lowercase: true },
-    teachers: {
-        ids: [String],
-        code: {type: String, required: false, lowercase: true }
-    },
-    teacher_assistants: {
-        ids: [String],
-        code: {type: String, required: false, lowercase: true }
-    },
-    students: {
-        ids: [String],
-        code: {type: String, required: true, lowercase: true }
-    }
+    schoolName: { type: String, required: false },
+    courseType: { type: String, required: false, lowercase: true },
+    courseNumber: { type: String, required: false, lowercase: true },
+    sectionNumber: { type: String, required: false, lowercase: true },
+    courseTitle: { type: String, required: true },
+    teachers: { type: [String], required: true, index: true },
+    teacherAssistants: { type: [String], required: false, index: true },
+    students: { type: [String], required: false, index: true }
 }, {
     timestamps: true,
 })
 
-function getCode() {
-    const buffer = crypto.randomBytes(24);
-    const code = buffer.toString('hex');
-    return code;
-}
+module.exports = mongoose.model("Classroom", classroomSchema);

--- a/src/server/models/classrooms.js
+++ b/src/server/models/classrooms.js
@@ -3,14 +3,14 @@
 const mongoose = require("mongoose");
 
 const classroomSchema = new mongoose.Schema({
-    schoolId: { type: "ObjectId", required: false, ref: "School" },
+    schoolId: { type: "ObjectId", ref: "School" },
     courseType: { type: String },
     courseNumber: { type: String },
     sectionNumber: { type: String },
     courseTitle: { type: String, required: true },
-    teachers: [{ type: "ObjectId", required: true, index: true, unique: true, ref: "User" }],
-    teacherAssistants: [{ type: "ObjectId", required: true, default: [], index: true, unique: true, ref: "User" }],
-    students: [{ type: "ObjectId", required: true, default: [], index: true, unique: true, ref: "User" }]
+    teachers: [{ type: "ObjectId", required: true, index: true, ref: "User" }],
+    teacherAssistants: [{ type: "ObjectId",  default: [], index: true, ref: "User" }],
+    students: [{ type: "ObjectId",  default: [], index: true, ref: "User" }]
 }, {
     timestamps: true,
 })

--- a/src/server/models/classrooms.js
+++ b/src/server/models/classrooms.js
@@ -1,26 +1,21 @@
 "use strict";
 
 const mongoose = require("mongoose");
-const crypto = require("crypto");
-const util = require("../util");
 
 const classroomSchema = new mongoose.Schema({
-    id: { type: String, lowercase: true, unique: true, default: getId },
-    schoolName: { type: String, required: false },
-    courseType: { type: String, required: false },
-    courseNumber: { type: String, required: false },
-    sectionNumber: { type: String, required: false },
+    schoolId: { type: "ObjectId", required: false, ref: "School" },
+    courseType: { type: String },
+    courseNumber: { type: String },
+    sectionNumber: { type: String },
     courseTitle: { type: String, required: true },
-    teachers: { type: [String], required: true, index: true },
-    teacherAssistants: { type: [String], required: false, index: true },
-    students: { type: [String], required: false, index: true }
+    teachers: [{ type: "ObjectId", required: true, index: true, unique: true, ref: "User" }],
+    teacherAssistants: [{ type: "ObjectId", required: true, default: [], index: true, unique: true, ref: "User" }],
+    students: [{ type: "ObjectId", required: true, default: [], index: true, unique: true, ref: "User" }]
 }, {
     timestamps: true,
 })
 
-function getId() {
-    return util.getKey(24);
-}
+
 
 module.exports = mongoose.model("Classroom", classroomSchema);
 

--- a/src/server/models/classrooms.js
+++ b/src/server/models/classrooms.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const mongoose = require("mongoose");
+const crypto = require("crypto");
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, lowercase: true, index: { unique: true } },
+  password: { type: String, required: true, select: false },
+  name: { type: String, required: true },
+  apiToken: { type: String, default: getToken, unique: true, select: false },
+}, {
+  timestamps: true,
+});
+
+// invite codes need to be unique across all of them
+// how to set unique for all of them?
+// consider different length codes and requirements for string length?
+const classroomSchema = new mongoose.Schema({
+    id: { type: String, required: true, lowercase: true, index: { unique: true} },
+    course_type: { type: String, required: true, lowercase: true },
+    course_number: { type: String, required: true, lowercase: true },
+    section_number: { type: String, required: false, lowercase: true },
+    teachers: {
+        ids: [String],
+        code: {type: String, required: false, lowercase: true }
+    },
+    teacher_assistants: {
+        ids: [String],
+        code: {type: String, required: false, lowercase: true }
+    },
+    students: {
+        ids: [String],
+        code: {type: String, required: true, lowercase: true }
+    }
+}, {
+    timestamps: true,
+})
+
+function getCode() {
+    const buffer = crypto.randomBytes(24);
+    const code = buffer.toString('hex');
+    return code;
+}

--- a/src/server/models/classrooms.js
+++ b/src/server/models/classrooms.js
@@ -1,13 +1,15 @@
 "use strict";
 
 const mongoose = require("mongoose");
+const crypto = require("crypto");
+const util = require("../util");
 
 const classroomSchema = new mongoose.Schema({
-    id: { type: String, required: true, lowercase: true, index: { unique: true} },
+    id: { type: String, lowercase: true, unique: true, default: getId },
     schoolName: { type: String, required: false },
-    courseType: { type: String, required: false, lowercase: true },
-    courseNumber: { type: String, required: false, lowercase: true },
-    sectionNumber: { type: String, required: false, lowercase: true },
+    courseType: { type: String, required: false },
+    courseNumber: { type: String, required: false },
+    sectionNumber: { type: String, required: false },
     courseTitle: { type: String, required: true },
     teachers: { type: [String], required: true, index: true },
     teacherAssistants: { type: [String], required: false, index: true },
@@ -16,4 +18,9 @@ const classroomSchema = new mongoose.Schema({
     timestamps: true,
 })
 
+function getId() {
+    return util.getKey(24);
+}
+
 module.exports = mongoose.model("Classroom", classroomSchema);
+

--- a/src/server/models/invite-codes.js
+++ b/src/server/models/invite-codes.js
@@ -2,17 +2,12 @@
 
 const mongoose = require("mongoose")
 const crypto = require("crypto");
+const util = require("../util");
 
 // types: { teacher:1, ta:2, student:3 }
 const inviteCodeSchema = new mongoose.Schema({
     classroom: { type: String, required: true, lowercase: true, index: true },
-    code: { 
-        type: String, 
-        required: true, 
-        lowercase: true, 
-        default: getCode, 
-        index: true 
-    },
+    code: { type: String, required: true, lowercase: true, default: getCode, index: true },
     type: { type: Number, required: true }
 }, {
     timestamps: true
@@ -32,9 +27,7 @@ class InviteCode {
 inviteCodeSchema.loadClass(InviteCode);
 
 function getCode() {
-    const buffer = crypto.randomBytes(16);
-    const code = buffer.toString('hex');
-    return code;
+    return util.getKey(6);
 }
 
 module.exports = mongoose.model("InviteCode", inviteCodeSchema);

--- a/src/server/models/invite-codes.js
+++ b/src/server/models/invite-codes.js
@@ -7,7 +7,7 @@ const util = require("../util");
 // types: { teacher:1, ta:2, student:3 }
 const inviteCodeSchema = new mongoose.Schema({
     classroom: { type: String, required: true, lowercase: true, index: true },
-    code: { type: String, required: true, lowercase: true, default: getCode, index: true },
+    code: { type: String, required: true, lowercase: true, default: getCode, index: { unique: true } },
     type: { type: Number, required: true }
 }, {
     timestamps: true

--- a/src/server/models/invite-codes.js
+++ b/src/server/models/invite-codes.js
@@ -5,9 +5,9 @@ const util = require("../util");
 
 // types: { teacher:1, ta:2, student:3 }
 const inviteCodeSchema = new mongoose.Schema({
-    classroom: { type: String, required: true, lowercase: true, index: true },
-    code: { type: String, required: true, lowercase: true, default: getCode, index: { unique: true } },
-    type: { type: Number, required: true }
+    classroom: { type: "ObjectId", index: true, ref: "Classroom" },
+    code: { type: String,  lowercase: true, default: getCode, index: true },
+    type: { type: Number }
 }, {
     timestamps: true
 })

--- a/src/server/models/invite-codes.js
+++ b/src/server/models/invite-codes.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const mongoose = require("mongoose")
-const crypto = require("crypto");
 const util = require("../util");
 
 // types: { teacher:1, ta:2, student:3 }
@@ -14,11 +13,11 @@ const inviteCodeSchema = new mongoose.Schema({
 })
 
 class InviteCode {
-    async validCode(code){
+    validCode(code){
         return code === this.code;
     }
 
-    async rotateCode() {
+    rotateCode() {
         this.code = getCode();
         return this.save();
     }

--- a/src/server/models/invite-codes.js
+++ b/src/server/models/invite-codes.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const mongoose = require("mongoose")
+const crypto = require("crypto");
+
+// types: { teacher:1, ta:2, student:3 }
+const inviteCodeSchema = new mongoose.Schema({
+    classroom: { type: String, required: true, lowercase: true, index: true },
+    code: { 
+        type: String, 
+        required: true, 
+        lowercase: true, 
+        default: getCode, 
+        index: true 
+    },
+    type: { type: Number, required: true }
+}, {
+    timestamps: true
+})
+
+class InviteCode {
+    async validCode(code){
+        return code === this.code;
+    }
+
+    async rotateCode() {
+        this.code = getCode();
+        return this.save();
+    }
+}
+
+inviteCodeSchema.loadClass(InviteCode);
+
+function getCode() {
+    const buffer = crypto.randomBytes(16);
+    const code = buffer.toString('hex');
+    return code;
+}
+
+module.exports = mongoose.model("InviteCode", inviteCodeSchema);

--- a/src/server/models/schools.js
+++ b/src/server/models/schools.js
@@ -3,12 +3,12 @@
 const mongoose = require("mongoose");
 
 const schoolSchema = new mongoose.Schema({
-    name: { type: String, required: true, index: true },
+    name: { type: String, required: true },
     address: { type: String, index: false },
-    city: { type: String, required: true, index: true },
-    state: { type: String, required: true, index: true },
-    country: { type: String, required: true, index: false },
-    zip: { type: Number, index: true },
+    city: { type: String, required: true },
+    state: { type: String, required: true },
+    country: { type: String, required: true },
+    zip: { type: Number },
     domain: { type: String }
 }, {
     timestamps: true

--- a/src/server/models/schools.js
+++ b/src/server/models/schools.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const mongoose = require("mongoose");
+
+const schoolSchema = new mongoose.Schema({
+    name: { type: String, required: true, index: true },
+    address: { type: String, index: false },
+    city: { type: String, required: true, index: true },
+    state: { type: String, required: true, index: true },
+    country: { type: String, required: true, index: false },
+    zip: { type: Number, index: true },
+    domain: { type: String }
+}, {
+    timestamps: true
+});
+
+class School {
+    validEmail(email){
+        return email.split("@")[1] === this.domain;
+    }
+}
+
+schoolSchema.loadClass(School);
+
+module.exports = mongoose.model("School", schoolSchema);

--- a/src/server/models/users.js
+++ b/src/server/models/users.js
@@ -13,7 +13,7 @@ const userSchema = new mongoose.Schema({
   firstName: { type: String, required: true },
   lastName: { type: String, required: true },
   apiToken: { type: String, default: getToken, unique: true, select: false },
-  verified: { type: Boolean, default: false, required: true }
+  verified: { type: Boolean, default: false }
 }, {
   timestamps: true,
 });

--- a/src/server/models/users.js
+++ b/src/server/models/users.js
@@ -13,6 +13,7 @@ const userSchema = new mongoose.Schema({
   firstName: { type: String, required: true },
   lastName: { type: String, required: true },
   apiToken: { type: String, default: getToken, unique: true, select: false },
+  verified: { type: Boolean, default: false, required: true }
 }, {
   timestamps: true,
 });

--- a/src/server/models/users.js
+++ b/src/server/models/users.js
@@ -3,6 +3,7 @@
 const mongoose = require("mongoose");
 const bcrypt = require("bcrypt");
 const crypto = require("crypto");
+const util = require("../util");
 
 const SALT_WORK_FACTOR = 12;
 
@@ -43,9 +44,7 @@ class User {
 userSchema.loadClass(User);
 
 function getToken() {
-  const buffer = crypto.randomBytes(48);
-  const token = buffer.toString('hex');
-  return token;
+  return util.getKey(48);
 }
 
 module.exports = mongoose.model("User", userSchema);

--- a/src/server/models/users.js
+++ b/src/server/models/users.js
@@ -10,7 +10,8 @@ const SALT_WORK_FACTOR = 12;
 const userSchema = new mongoose.Schema({
   email: { type: String, required: true, lowercase: true, index: { unique: true } },
   password: { type: String, required: true, select: false },
-  name: { type: String, required: true },
+  firstName: { type: String, required: true },
+  lastName: { type: String, required: true },
   apiToken: { type: String, default: getToken, unique: true, select: false },
 }, {
   timestamps: true,

--- a/src/server/routes/api/classrooms/index.js
+++ b/src/server/routes/api/classrooms/index.js
@@ -6,7 +6,7 @@ const InviteCodes = require("../../../models/invite-codes");
 const mongoose = require("mongoose");
 var classCodes = [];
 
-
+// returns a list of classrooms this user belongs to
 router.get("/", async (req, res) => {
     if (req.isAuthenticated()) {
         Classrooms.find({ $or: [ 
@@ -23,6 +23,7 @@ router.get("/", async (req, res) => {
     }
 });
 
+// updates a classroom document by classroomId
 router.put("/id/:classroomId", async (req, res) => {
     if (req.isAuthenticated()) {
         Classrooms.findOneAndUpdate(
@@ -43,6 +44,7 @@ router.put("/id/:classroomId", async (req, res) => {
     }
 });
   
+// adds user to the listing for a classroom based on a given invite code
 router.post("/join", async (req, res) => {
     if (req.isAuthenticated()) {
         const qCode = req.body.inviteCode
@@ -78,6 +80,7 @@ router.post("/join", async (req, res) => {
     }
 });
 
+// creates a classroom and returns invite codes for teachers, TAs, and students
 router.post("/", async (req, res) => {
     if (req.isAuthenticated()) {
         try {

--- a/src/server/routes/api/classrooms/index.js
+++ b/src/server/routes/api/classrooms/index.js
@@ -6,32 +6,32 @@ const InviteCodes = require("../../../models/invite-codes");
 const mongoose = require("mongoose");
 var classCodes = [];
 
+
 router.get("/", async (req, res) => {
     if (req.isAuthenticated()) {
-        const classrooms = await Classrooms.find(
-            { $or: [ 
-                {teachers: req.user._id },
-                {teacherAssistants: req.user._id },
-                {students: req.user._id }
-            ]}
-        );
-        res.json(classrooms);
+        Classrooms.find({ $or: [ 
+                { teachers: req.user._id },
+                { teacherAssistants: req.user._id },
+                { students: req.user._id }
+        ]}).then(classrooms => {
+            res.json(classrooms);
+        }).catch( err => {
+            res.json({ status: false, message: err });
+        })
     } else {
         res.status(401).send();
     }
-  });
+});
 
 router.put("/id/:classroomId", async (req, res) => {
     if (req.isAuthenticated()) {
-        console.log("req.params.classroomId: " + req.params.id);
-        console.log("req.user._id: " + req.user._id);
         Classrooms.findOneAndUpdate(
             { $and: [ { id: req.params.classroomId } , { teachers: mongoose.Types.ObjectId(req.user._id) } ] },
             { $set: req.body }
         ).then( classroom => {
             console.log(classroom);
             if( classroom !== null ){
-                res.json({status: true, message: "Class was successfully updated" });
+                res.json({status: true, message: "Class was successfully updated", classroom: classroom });
             } else {
                 res.json({status: false, message: "Cannot find/modify class" });
             }
@@ -41,7 +41,7 @@ router.put("/id/:classroomId", async (req, res) => {
     } else {
         res.status(401).send();
     }
-})
+});
   
 router.post("/join", async (req, res) => {
     if (req.isAuthenticated()) {
@@ -76,7 +76,7 @@ router.post("/join", async (req, res) => {
     } else {
         res.status(401).send();
     }
-  });
+});
 
 router.post("/", async (req, res) => {
     if (req.isAuthenticated()) {

--- a/src/server/routes/api/classrooms/index.js
+++ b/src/server/routes/api/classrooms/index.js
@@ -3,8 +3,6 @@
 const router = require("express").Router();
 const Classrooms = require("../../../models/classrooms");
 const InviteCodes = require("../../../models/invite-codes");
-const mongoose = require("mongoose");
-var classCodes = [];
 
 // returns a list of classrooms this user belongs to
 router.get("/", async (req, res) => {
@@ -17,7 +15,46 @@ router.get("/", async (req, res) => {
             res.json(classrooms);
         }).catch( err => {
             res.json({ status: false, message: err });
-        })
+        });
+    } else {
+        res.status(401).send();
+    }
+});
+
+// creates a classroom and returns invite codes for teachers, TAs, and students
+router.post("/", async (req, res) => {
+    if (req.isAuthenticated()) {
+        const userTypes = [1,2,3];
+        Classrooms.create({
+            schoolId: req.body.schoolId,
+            courseType: req.body.courseType,
+            courseNumber: req.body.courseNumber,
+            sectionNumber: req.body.sectionNumber,
+            courseTitle: req.body.courseTitle,
+            teachers: [req.user._id],
+            teacherAssistants: [],
+            students: []
+        }).catch((err) => {
+            res.json({ success: false, message: err });
+        }).then( classroom => {
+            Promise.all(userTypes.map( n => {
+                return InviteCodes.create({
+                    classroom: classroom.id,
+                    type: n
+                }) 
+            })).then( values => {
+                var inviteCodes = values.map( invite => {
+                    return invite.code;
+                });
+                res.json({
+                    teachers: inviteCodes[0],
+                    teacherAssistants: inviteCodes[1],
+                    students: inviteCodes[2]
+                });
+            }).catch( err => {
+                res.json({ success: false, message: err });
+            });
+        });
     } else {
         res.status(401).send();
     }
@@ -27,7 +64,7 @@ router.get("/", async (req, res) => {
 router.put("/id/:classroomId", async (req, res) => {
     if (req.isAuthenticated()) {
         Classrooms.findOneAndUpdate(
-            { $and: [ { id: req.params.classroomId } , { teachers: mongoose.Types.ObjectId(req.user._id) } ] },
+            { $and: [ { id: req.params.classroomId } , { teachers: req.user._id } ] },
             { $set: req.body }
         ).then( classroom => {
             console.log(classroom);
@@ -43,7 +80,7 @@ router.put("/id/:classroomId", async (req, res) => {
         res.status(401).send();
     }
 });
-  
+
 // adds user to the listing for a classroom based on a given invite code
 router.post("/join", async (req, res) => {
     if (req.isAuthenticated()) {
@@ -65,60 +102,24 @@ router.post("/join", async (req, res) => {
                 default:
                     throw Error("No matching code type for " + validCode);
             }
-            Classrooms.update (
-                { id: validCode.classroom },
-                {$push: listUpdate},
-                { upsert: true },
-                function(err, data){}
-            );
-            res.json({success: true, message: "Successfully added you to the classroom" });
+            Classrooms.update(
+                { _id: validCode.classroom },
+                { $addToSet: listUpdate },
+                { upsert: false }
+            ).then( classUpdate => {
+                console.log(classUpdate);
+                if(classUpdate.ok === 1){
+                    res.json({ success: true, message: "You successfully belong to the classroom" });
+                } else {
+                    res.json({ success: false, message: "You could not be added to that classroom" });
+                }
+            }).catch( err => {
+                res.json({ success: false, message: err });
+            });
+            
         }).catch( err => {
             res.json({success: false, message: err });
         });
-    } else {
-        res.status(401).send();
-    }
-});
-
-// creates a classroom and returns invite codes for teachers, TAs, and students
-router.post("/", async (req, res) => {
-    if (req.isAuthenticated()) {
-        try {
-            const userTypes = [1,2,3];
-            Classrooms.create({
-                schoolName: req.body.schoolName,
-                courseType: req.body.courseType,
-                courseNumber: req.body.courseNumber,
-                sectionNumber: req.body.sectionNumber,
-                courseTitle: req.body.courseTitle,
-                teachers: [req.user._id],
-                teacherAssistants: [],
-                students: []
-            }).catch((err) => {
-                res.json({success: false, message: err});
-            }).then( classroom => {
-                Promise.all(userTypes.map( n => {
-                    return InviteCodes.create({
-                        classroom: classroom.id,
-                        type: n
-                    }) 
-                })).then( values => {
-                    var inviteCodes = values.map( invite => {
-                        return invite.code;
-                    });
-                    res.json({
-                        teachers: inviteCodes[0],
-                        teacherAssistants: inviteCodes[1],
-                        students: inviteCodes[2]
-                    });
-                }).catch( err => {
-                    res.json({ success: false, message: err });
-                });
-            });
-
-        } catch(err) {
-            res.json({success: false, message: err});
-        }
     } else {
         res.status(401).send();
     }

--- a/src/server/routes/api/classrooms/index.js
+++ b/src/server/routes/api/classrooms/index.js
@@ -1,0 +1,90 @@
+"use strict";
+
+const router = require("express").Router();
+const Classrooms = require("../../../models/classrooms");
+const InviteCodes = require("../../../models/invite-codes");
+const mongoose = require("mongoose");
+var classCodes = [];
+
+router.get("/", async (req, res) => {
+    if (req.isAuthenticated()) {
+      const classrooms = await Classrooms.find();
+      res.json(classrooms);
+    } else {
+      res.status(401).send();
+    }
+  });
+  
+router.post("/join", async (req, res) => {
+    if (req.isAuthenticated()) {
+      res.json({username: req.user});
+    } else {
+      res.status(401).send();
+    }
+  });
+
+router.post("/", async (req, res) => {
+    if (req.isAuthenticated()) {
+        console.log(req.user);
+        classCodes = [];
+        try {
+            const userTypes = [1,2,3]
+
+            const classroom = Classrooms.create({
+                schoolName: req.body.schoolName,
+                courseType: req.body.courseType,
+                courseNumber: req.body.courseNumber,
+                sectionNumber: req.body.sectionNumber,
+                courseTitle: req.body.courseTitle,
+                teachers: [req.user._id],
+                teacherAssistants: [],
+                students: []
+            }).catch((err) => {
+                console.log(err);
+            });
+            console.log(classroom);
+            classroom.then( function(doc) {
+                userTypes.forEach( function(n) {
+                    const inviteCode = InviteCodes.create({
+                        classroom: doc.id,
+                        type: n
+                    });
+                    inviteCode.then( function(inv) {
+                        console.log(inv.code);
+                        classCodes.push(inv.code);
+                        console.log(classCodes);
+                    }).catch((err) => {
+                        classCodes.push("error");
+                    });
+                });
+            });
+            console.log(classCodes);
+            
+            codePromise.then((v)=>{
+                res.json({
+                    teachers: classCodes[0],
+                    teacherAssistants: classCodes[1],
+                    students: classCodes[2]
+                });
+            });
+            
+
+        } catch(err) {
+            console.log(err);
+            errStatus(res,err);
+        }
+    } else {
+        res.status(401).send();
+    }
+})
+
+const addCode = function (code){
+    classCodes.push(code);
+}
+
+const errStatus = function(res, err){
+    res.json({success: False, message: err});
+}
+
+module.exports = router;
+

--- a/src/server/routes/api/classrooms/index.js
+++ b/src/server/routes/api/classrooms/index.js
@@ -21,7 +21,6 @@ router.post("/join", async (req, res) => {
         InviteCodes.findOne(
           { code: qCode }
         ).then( validCode => {
-            console.log(validCode);
             var listUpdate = {};
             switch(validCode.type) {
                 case 1:
@@ -36,7 +35,6 @@ router.post("/join", async (req, res) => {
                 default:
                     throw Error("No matching code type for " + validCode);
             }
-            console.log("listUpdate = " + listUpdate);
             Classrooms.update (
                 { id: validCode.classroom },
                 {$push: listUpdate},
@@ -45,7 +43,6 @@ router.post("/join", async (req, res) => {
             );
             res.json({success: true, message: "Successfully added your to classroom" });
         }).catch( err => {
-            console.log(err);
             res.json({success: false, message: err });
         });
     } else {
@@ -67,7 +64,6 @@ router.post("/", async (req, res) => {
                 teacherAssistants: [],
                 students: []
             }).catch((err) => {
-                console.log("Error occurred in request");
                 res.json({success: false, message: err});
             }).then( classroom => {
                 Promise.all(userTypes.map( n => {
@@ -85,12 +81,11 @@ router.post("/", async (req, res) => {
                         students: inviteCodes[2]
                     });
                 }).catch( err => {
-                    console.log("Waiting on follow-up codes..");
+                    res.json({ success: false, message: err });
                 });
             });
 
         } catch(err) {
-            console.log(err);
             res.json({success: false, message: err});
         }
     } else {

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -30,14 +30,7 @@ router.get("/users", async (req, res) => {
   }
 });
 
-router.get("/classrooms", async (req, res => {
-  if (req.isAuthenticated()) {
-    const classrooms = await Classrooms.find();
-    res.json(classrooms);
-  } else {
-    res.status(401).send();
-  }
-}));
+
 
 module.exports = router;
 

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -2,7 +2,6 @@
 
 const router = require("express").Router();
 const Users = require("../../models/users");
-const Classrooms = require("../../models/classrooms");
 const passport = require("passport");
 
 router.get("/", (req, res) => {

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -2,6 +2,7 @@
 
 const router = require("express").Router();
 const Users = require("../../models/users");
+const Classrooms = require("../../models/classrooms");
 const passport = require("passport");
 
 router.get("/", (req, res) => {
@@ -28,6 +29,15 @@ router.get("/users", async (req, res) => {
     res.status(401).send();
   }
 });
+
+router.get("/classrooms", async (req, res => {
+  if (req.isAuthenticated()) {
+    const classrooms = await Classrooms.find();
+    res.json(classrooms);
+  } else {
+    res.status(401).send();
+  }
+}));
 
 module.exports = router;
 

--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -30,7 +30,8 @@ router.get("/users", async (req, res) => {
   }
 });
 
-
+router.use("/classrooms", require("./classrooms"));
+router.use("/schools", require("./schools"));
 
 module.exports = router;
 

--- a/src/server/routes/api/schools/index.js
+++ b/src/server/routes/api/schools/index.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const router = require("express").Router();
+const Schools = require("../../../models/schools");
+
+// returns a list of all schools
+router.get("/", async (req, res) => {
+    const schools = await Schools.find(req.query);
+    res.json(schools);
+});
+
+// create a school
+router.post("/", async (req, res) => {
+    if(req.isAuthenticated()){
+        Schools.create({
+            name: req.body.name,
+            address: req.body.address,
+            city: req.body.city,
+            state: req.body.state,
+            country: req.body.country,
+            zip: req.body.zip,
+            domain: req.body.domain
+        }).then( school => {
+            res.json(school);
+        }).catch( err => {
+            res.json({ sucess: false, message: err });
+        });
+    } else {
+        res.status(401).send();
+    }
+});
+
+// update a school by schoolId
+router.put("/id/:schoolId", (req, res) => {
+    if(req.isAuthenticated()){
+        Schools.update(
+            { _id: req.params.schoolId },
+            { $set: req.body }
+        ).then( school => {
+            console.log(school);
+            res.json({ success: true, message: "School successfully updated" })
+        }).catch( err => {
+            res.json({ success: false, message: err });
+        })
+    } else {
+        res.status(401).send();
+    }
+});
+
+module.exports = router;
+

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -27,6 +27,7 @@ router.post("/register", async (req, res) => {
 });
 
 router.use("/api/v1", require("./api"));
+router.use("/api/v1/classrooms", require("./api/classrooms"));
 
 module.exports = router;
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -18,16 +18,17 @@ router.post("/register", async (req, res) => {
     const user = await Users.create({
       email: req.body.email,
       password: req.body.password,
-      name: req.body.name,
+      firstName: req.body.firstName,
+      lastName: req.body.lastName
     });
     res.json(user);
   } catch (err) {
-    res.status(400).json({ message: "User already exists" });
+    res.status(400).json({ message: err});
   }
 });
 
 router.use("/api/v1", require("./api"));
-router.use("/api/v1/classrooms", require("./api/classrooms"));
+
 
 module.exports = router;
 

--- a/src/server/util/index.js
+++ b/src/server/util/index.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const crypto = require("crypto");
+
+module.exports.getKey = (size) => {
+    const buffer = crypto.randomBytes(size);
+    const key = buffer.toString('hex');
+    return key;
+}


### PR DESCRIPTION
This PR introduces the Classroom and InviteCode collections for MongoDB, and adds API functionality for them. They are not feature complete entirely, but the routes added thus far are tested and working. 

API functionality:

* return a list of classrooms in the system
* create a classroom (there are some required fields and it fails if not provided) and return invite codes for teachers, TAs, and students
* join a classroom by invitation code and correctly add them to that classrooms list of students, teachers, and TAs by `user._id`

New `util` folder added due to reused token generation functionality across multiple files. This so far contains only the `getKey(sizeOfKey)` functionality that is used by the models for generated unique IDs, invite codes, and more. 